### PR TITLE
Fix internal HTTP client imports

### DIFF
--- a/feedback-agent/services/tts_gate.js
+++ b/feedback-agent/services/tts_gate.js
@@ -1,5 +1,5 @@
 'use strict';
-const { http } = require('./services-http_client');
+const { http } = require('./http_client');
 
 exports.ttsMaybe = async (text) => {
   try {

--- a/feedback-agent/utils/normalize.js
+++ b/feedback-agent/utils/normalize.js
@@ -1,5 +1,5 @@
 'use strict';
-const { http } = require('./services-http_client');
+const { http } = require('../services/http_client');
 
 const SUPPORTED_POSES = [
   'mountain_pose','warrior_1','warrior_2','tree_pose','downward_dog','triangle_pose'


### PR DESCRIPTION
## Summary
- fix the TTS gate to import the shared HTTP client correctly
- update normalize utility to reference the shared HTTP client module via the proper relative path

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cac27674508329b87a514a6ea55bf0